### PR TITLE
Switch accent-color to primary-color

### DIFF
--- a/styles.js
+++ b/styles.js
@@ -1,10 +1,6 @@
 import { css } from "https://unpkg.com/lit-element@2.4.0/lit-element.js?module";
 
 export const styles = css`
-  :host {
-    --primary-color: #4CAF50;
-    --background-color: #f5f5f5;
-  }
   .vehicle-card-content {
     padding: 16px;
   }
@@ -67,7 +63,7 @@ export const styles = css`
     width: 0;
     height: 1.5rem;
     margin: 0;
-    background-color: var(--accent-color, var(--primary-color));
+    background-color: var(--primary-color);
     border-radius: 4px;
   }
   .level-text {
@@ -221,7 +217,7 @@ export const styles = css`
     margin-top: 8px;
   }
   .selected-entity {
-    background-color: var(--accent-color);
+    background-color: var(--primary-color);
     color: var(--text-primary-color, white);
     padding: 8px;
     border-radius: 4px;

--- a/ultra-vehicle-card-editor.js
+++ b/ultra-vehicle-card-editor.js
@@ -89,7 +89,7 @@ export class UltraVehicleCardEditor extends LitElement {
           align-items: center;
           justify-content: space-between;
           padding: 4px 8px;
-          background-color: var(--accent-color);
+          background-color: var(--primary-color);
           color: var(--text-primary-color);
           border-radius: 4px;
         }

--- a/ultra-vehicle-card.js
+++ b/ultra-vehicle-card.js
@@ -172,7 +172,7 @@ _renderVehicleImage() {
     const state = entity.state;
 
     const isActive = ['on', 'open', 'true', 'unlocked'].includes(state.toLowerCase());
-    const iconColor = isActive ? 'var(--accent-color)' : 'var(--secondary-text-color)';
+    const iconColor = isActive ? 'var(--primary-color)' : 'var(--secondary-text-color)';
 
     return html`
       <div class="icon-item">


### PR DESCRIPTION
This PR removes the stylesheet variable overrides and switches `accent-color` to `primary-color` in a few places.

I believe this follows Material Design more closely and allows end users to change colors with their Home Assistant theme settings. 

Let me know what you think :) 