### PR TITLE
Versioning added to secondary .js files

### DIFF
--- a/dist/ultra-vehicle-card-editor.js
+++ b/dist/ultra-vehicle-card-editor.js
@@ -4,8 +4,11 @@ import {
   css,
 } from "https://unpkg.com/lit-element@2.4.0/lit-element.js?module";
 import { version } from './version.js';
-import { styles } from './styles.js';
-import { localize } from './localize.js';
+
+const stl = await import ('./styles.js?v='+version);
+const loc = await import ('./localize.js?v='+version);
+const styles = stl.styles;
+const localize = loc.localize;
 
 const DEFAULT_IMAGE_URL = 'https://github.com/user-attachments/assets/4ef72288-5ee9-4fa6-b2f3-c34c4160cf42';
 const DEFAULT_IMAGE_TEXT = 'Default Image';

--- a/dist/ultra-vehicle-card.js
+++ b/dist/ultra-vehicle-card.js
@@ -1,8 +1,12 @@
 import { LitElement, html, css } from "https://unpkg.com/lit-element@2.4.0/lit-element.js?module";
-import { version } from './version.js';
-import { UltraVehicleCardEditor } from './ultra-vehicle-card-editor.js';
-import { styles } from './styles.js';
-import { localize } from './localize.js';
+import { version, setVersion } from './version.js';
+setVersion('V1.5.2');
+
+const UltraVehicleCardEditor = await import ('./ultra-vehicle-card-editor.js?v='+version);
+const stl = await import ('./styles.js?v='+version);
+const loc = await import ('./localize.js?v='+version);
+const styles = stl.styles;
+const localize = loc.localize;
 
 class UltraVehicleCard extends localize(LitElement) {
   static get properties() {

--- a/dist/version.js
+++ b/dist/version.js
@@ -1,1 +1,8 @@
-export const version = 'V1.5.1';
+// Do not change this file, any change requires all clients to forcefully clear the cache.
+
+let version = 'undefined';
+function setVersion(value) {
+  version = value;
+}
+
+export { version, setVersion };


### PR DESCRIPTION
Added ultra-vehicle-card-editor.js, localize.js and styles.js files to auto refresh on version updates.

Version number moved to ultra-vehicle-card.js

version.js should no longer be changed, any change requires all clients to manually clear caches.

resolves #50