### PR TITLE
Added versioning to version.js

### DIFF
--- a/dist/ultra-vehicle-card-editor.js
+++ b/dist/ultra-vehicle-card-editor.js
@@ -3,7 +3,7 @@ import {
   html,
   css,
 } from "https://unpkg.com/lit-element@2.4.0/lit-element.js?module";
-import { version } from './version.js';
+import { version } from './version.js?v=1';
 
 const stl = await import ('./styles.js?v='+version);
 const loc = await import ('./localize.js?v='+version);

--- a/dist/ultra-vehicle-card.js
+++ b/dist/ultra-vehicle-card.js
@@ -1,6 +1,6 @@
 import { LitElement, html, css } from "https://unpkg.com/lit-element@2.4.0/lit-element.js?module";
-import { version, setVersion } from './version.js';
-setVersion('V1.5.3');
+import { version, setVersion } from './version.js?v=1';
+setVersion('V1.5.4');
 
 const UltraVehicleCardEditor = await import ('./ultra-vehicle-card-editor.js?v='+version);
 const stl = await import ('./styles.js?v='+version);

--- a/dist/version.js
+++ b/dist/version.js
@@ -1,4 +1,5 @@
-// Do not change this file, any change requires all clients to forcefully clear the cache.
+// Upon any change to this file update 'import ... from 'version.js?v=0'' with a newer version number.
+// In all files importing this file.
 
 let version = 'undefined';
 function setVersion(value) {


### PR DESCRIPTION
Manual update of the `version.js` import links is required upon changes of the `version.js` file.

Resolves #59 